### PR TITLE
draft: Apache's HTTP/2 Double-Free Was Also an ASLR Bypass

### DIFF
--- a/content/blog/apache-http2-double-free-cve-2026-23918.mdx
+++ b/content/blog/apache-http2-double-free-cve-2026-23918.mdx
@@ -1,0 +1,138 @@
+---
+title: "Apache's HTTP/2 Double-Free Was Also an ASLR Bypass"
+description: "CVE-2026-23918 crashes any Apache 2.4.66 worker with two HTTP/2 frames. On Debian and the official Docker image, it is remote code execution. The scoreboard is why."
+date: "2026-05-17"
+updated: "2026-05-17"
+tags: ["security", "vulnerability", "software", "essay"]
+cover: "/blog/covers/apache-http2-double-free-cve-2026-23918.svg"
+coverAlt: "Dark orange gradient cover with the post title in white"
+accent: "orange"
+draft: true
+featured: false
+---
+
+I found [CVE-2026-23918](https://thehackernews.com/2026/05/critical-apache-http2-flaw-cve-2026.html) while updating a client dependency list last week. Apache 2.4.66. Affected. Fix available in 2.4.67. The patch took less time to apply than to read.
+
+I spent the next hour reading it anyway.
+
+The short version: CVE-2026-23918 is a double-free in `mod_http2`'s stream cleanup path, disclosed May 5 and patched in 2.4.67. One TCP connection and two HTTP/2 frames is enough to crash an Apache worker. On Debian-based systems and the official Apache Docker image, that same double-free becomes a path to remote code execution without requiring a memory disclosure gadget.
+
+The reason is the scoreboard. Apache has been shipping it since version 1.3. It sits at a fixed address that ASLR cannot touch.
+
+## The bug in h2_mplx.c
+
+`mod_http2` manages concurrent HTTP/2 streams through a structure called `h2_mplx`. Each stream gets a corresponding `h2_stream` object. When a stream ends, the multiplexer cleans it up by calling `h2_stream_destroy`, which calls `apr_pool_destroy` on the stream's memory pool.
+
+The cleanup path runs through a function called `m_stream_cleanup`. Under normal operation, one call per stream. The bug arranges for two.
+
+The trigger is a specific frame sequence:
+
+1. Client sends a `HEADERS` frame on stream N.
+2. Before the multiplexer registers stream N, the client immediately sends `RST_STREAM` on stream N with a non-zero error code.
+
+That sequence causes two separate nghttp2 callbacks to fire in close succession:
+
+```
+on_frame_recv_cb  (RST)   -> h2_mplx_c1_client_rst -> m_stream_cleanup
+on_stream_close_cb (close) -> h2_mplx_c1_client_rst -> m_stream_cleanup
+```
+
+Both callbacks reach the same cleanup function. Both push the same `h2_stream` pointer onto a deferred cleanup array called `spurge`. When `c1_purge_streams` later iterates `spurge` and calls `h2_stream_destroy` on each entry, the first call is fine. The second call runs `apr_pool_destroy(stream->pool)` on memory that was already freed.
+
+That is the double-free. One TCP connection. Two HTTP/2 frames. No authentication required. Apache worker process crashes.
+
+The denial-of-service case ends there. It is repeatable indefinitely because the server respawns the crashed worker, and a single socket in a tight loop can keep the server perpetually overloaded. You do not need to own a botnet for this. You need a laptop and a network path to port 443.
+
+## What makes this RCE on the default Docker image
+
+A double-free on a 64-bit system with ASLR enabled usually requires an information disclosure gadget before it becomes useful. You need to know where something is before you can redirect execution to it. Most write-ups about heap corruption bugs spend pages on the spray-and-leak dance required to hit a useful address.
+
+CVE-2026-23918 skips most of that dance on Debian-derived systems and the official `httpd` Docker image. The reason is how the Apache Portable Runtime allocates memory on these configurations: using `mmap` rather than `malloc`. On APR-backed heaps, freed memory can be re-mapped by a subsequent allocation, and if you control the allocation, you control what the second `apr_pool_destroy` call touches.
+
+After the double-free, an attacker races a new stream allocation to reclaim the freed `h2_stream` object and substitute attacker-controlled content. The `h2_stream` struct contains cleanup function pointers. Overwrite one of those pointers and the next cleanup call becomes instruction pointer control.
+
+Getting from instruction pointer control to code execution still requires a writable, executable (or return-oriented) region at a known address. On a hardened 64-bit system, this is normally the hard part.
+
+On Apache, it is not hard. The reason is the scoreboard.
+
+## The scoreboard
+
+Apache has had a process scoreboard since version 1.3. It is a shared memory region that tracks worker state: which slots are active, what requests they are handling, how long they have been running. `apachectl status` reads from it. Load balancers poll it. The `ap_update_child_status` API writes to it throughout normal request handling.
+
+The scoreboard is allocated early in Apache's startup sequence, before the main heap, via an `mmap` call that runs before the kernel applies ASLR randomization to the process. This is not an oversight. The scoreboard needs to be shared across worker processes that fork _after_ it exists, so it has to be created before the fork. ASLR randomizes addresses at load time. The scoreboard is placed before that boundary. The kernel cannot retroactively randomize it.
+
+The scoreboard lives at a fixed address for the entire lifetime of the server process. Enable ASLR. Enable PIE. Enable every mitigation the kernel ships. The scoreboard is still there, at the same address it was always at, containing worker process state that normal Apache code writes to on every request.
+
+[Hadrian's technical writeup](https://hadrian.io/blog/cve-2026-23918-apache-http-server-double-free-rce-in-http-2-implementation) calls the exploitation path "practical." That is the right word. The RCE path for CVE-2026-23918 on Debian and the official Docker image does not require an information leak because the target address is not random. You do not need to spray. You do not need to brute-force. You point the hijacked function pointer at scoreboard memory you have already primed with payload, and the server walks into it.
+
+## The fix
+
+The patch in 2.4.67 is three lines. Apache added a boolean field to `h2_stream` named `rst_received`. The first call to `m_stream_cleanup` sets it. The second call checks it, finds it set, and returns without pushing to `spurge`.
+
+```c
+/* simplified illustration of the 2.4.67 guard */
+static void m_stream_cleanup(h2_mplx *m, h2_stream *stream) {
+    if (stream->rst_received) return;
+    stream->rst_received = 1;
+    /* ... proceed: push stream onto spurge, schedule cleanup ... */
+}
+```
+
+The stream pointer enters the cleanup queue once. `apr_pool_destroy` runs once. The double-free does not happen.
+
+Three lines. That is the full distance between a practical, no-disclosure-gadget-needed RCE path on the default Docker image and a web server that works correctly. The disproportion between fix complexity and impact is not unusual in memory-safety bugs. It does not get less striking each time.
+
+## Who is exposed
+
+[Only Apache 2.4.66 is affected](https://securityaffairs.com/191759/security/apache-fixes-critical-http-2-double-free-flaw-cve-2026-23918-enabling-rce.html). Not 2.4.65. Not 2.4.64. One release. 2.4.67 has the fix.
+
+2.4.66 shipped in late March 2026 and immediately became the `latest` stable release. Every `apt install apache2`, every `docker pull httpd:latest`, every Helm chart pulling the default image between late March and May 8 landed on a vulnerable version.
+
+The official `httpd` Docker image was updated to 2.4.67 on May 8. Before that date, the canonical "pull and run" Apache container was vulnerable. On Debian, which is the base for the official Docker image, the RCE conditions are met out of the box: APR uses the mmap allocator, `mod_http2` is loaded, and the MPM is event-based (multi-threaded, not prefork).
+
+Check your version:
+
+```bash
+# Direct binary
+httpd -v
+
+# Inside a running container
+docker exec <container-id> httpd -v
+
+# In a Kubernetes pod
+kubectl exec <pod-name> -- httpd -v
+```
+
+Patched output looks like:
+
+```
+Server version: Apache/2.4.67 (Unix)
+```
+
+If you see `2.4.66`, update the image and redeploy. On package-managed systems, Ubuntu, Debian, and Red Hat have all pushed 2.4.67 through their security channels. `apt upgrade apache2` or `dnf update httpd` should resolve it; check your distribution's advisory for the exact package version to confirm.
+
+If you cannot update immediately, disabling `mod_http2` cuts off the vulnerable code path entirely:
+
+```apache
+# In httpd.conf or the relevant virtual host config
+# LoadModule http2_module modules/mod_http2.so
+Protocols http/1.1
+```
+
+HTTP/1.1 degrades multiplexed performance, but the server stops double-freeing stream objects. Acceptable interim state while you arrange the upgrade.
+
+## The scoreboard is not going anywhere
+
+The 2.4.67 patch fixes the double-free. It does not change anything about the scoreboard.
+
+The scoreboard's fixed-address placement is not a bug. It is a design property rooted in a requirement that predates ASLR by a decade: shared memory across forked worker processes that need consistent state before any of them starts. The fix for the scoreboard's ASLR-blindness, if there is one, would require either moving it into post-fork shared memory with a randomized base, or redesigning the fork model. That is a significant architectural change to code that has been stable and correct since 1998. Nobody is proposing it because the scoreboard, by itself, does nothing dangerous.
+
+The danger is the combination: a memory corruption primitive with attacker-controlled allocation, plus a fixed-address writable region, plus a widely deployed default configuration where both conditions hold simultaneously.
+
+CVE-2026-23918 is fixed. The scoreboard is still there. The next memory corruption bug in `mod_http2`, or in any other Apache module that handles untrusted input and allocates heap objects, will find it at the same address it was at today.
+
+The general defense is unchanged: stay current, minimize loaded modules to what you use, and do not treat "enabled by default" as a signal about security posture. `mod_http2` is enabled by default because HTTP/2 is useful. That does not mean it has been audited more carefully than anything else. The history of HTTP/2 vulnerabilities across implementations suggests the opposite.
+
+If you run Apache and have not audited your loaded module list recently, this is a reasonable prompt to do that. The question to ask for each module is: does this module accept data from the network and allocate memory based on it? If yes, is it current? The list of modules that answer yes to the first question is longer than most people expect when they check.
+
+Patch to 2.4.67. The scoreboard will be there waiting for the next one.

--- a/public/blog/covers/apache-http2-double-free-cve-2026-23918.svg
+++ b/public/blog/covers/apache-http2-double-free-cve-2026-23918.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Apache's HTTP/2 Double-Free Was Also an ASLR Bypass">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0a04"/>
+      <stop offset="55%" stop-color="#1a1005"/>
+      <stop offset="100%" stop-color="#1f1206"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.68" cy="0.32" r="0.58">
+      <stop offset="0%" stop-color="rgba(249,115,22,0.30)"/>
+      <stop offset="55%" stop-color="rgba(249,115,22,0.07)"/>
+      <stop offset="100%" stop-color="rgba(249,115,22,0)"/>
+    </radialGradient>
+    <radialGradient id="glow2" cx="0.10" cy="0.85" r="0.45">
+      <stop offset="0%" stop-color="rgba(234,88,12,0.12)"/>
+      <stop offset="100%" stop-color="rgba(234,88,12,0)"/>
+    </radialGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#grid)"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+  <rect width="1600" height="900" fill="url(#glow2)"/>
+
+  <g font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" fill="#fff7ed">
+    <text x="120" y="180" font-size="28" fill="#fdba74" letter-spacing="3">AYUSHSHARMA.ME · BLOG</text>
+
+    <text x="120" y="390" font-size="92" font-weight="700" letter-spacing="-2">
+      <tspan x="120" dy="0">Apache's HTTP/2</tspan>
+      <tspan x="120" dy="112">Double-Free Was</tspan>
+      <tspan x="120" dy="112">Also an ASLR Bypass</tspan>
+    </text>
+
+    <text x="120" y="800" font-size="28" fill="#94a3b8">
+      <tspan fill="#f97316" font-weight="700">/ </tspan>Ayush Sharma
+    </text>
+    <text x="1480" y="800" font-size="24" fill="#64748b" text-anchor="end">CVE-2026-23918</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Topic
CVE-2026-23918: a double-free in Apache mod_http2 that crashes any 2.4.66 worker with two HTTP/2 frames, and on Debian plus the official Docker image becomes RCE because the process scoreboard is at a fixed address ASLR cannot touch.

## Category
vulnerability

## Thesis
The double-free in CVE-2026-23918 is a one-connection DoS on any 2.4.66 deployment and a no-disclosure-gadget-needed RCE on the default Docker image, because Apache's scoreboard has been sitting at a fixed pre-ASLR address since version 1.3.

## Why now
Disclosed May 5, 2026. Patched in 2.4.67. The official `httpd` Docker image was only updated on May 8. Any container image pulled between late March and May 8 is still running vulnerable software. Source: [The Hacker News, May 2026](https://thehackernews.com/2026/05/critical-apache-http2-flaw-cve-2026.html)

## Stats
- Word count: 1594
- Reading time: ~7 min
- Tags: security, vulnerability, software, essay

## Status
`draft: true` in frontmatter. Will NOT appear on live site. Flip to `draft: false` to publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM7tMFcAMZNt8TAJi9mZEn)_